### PR TITLE
handle long file names when making a tempfile

### DIFF
--- a/lib/audio_monster/monster.rb
+++ b/lib/audio_monster/monster.rb
@@ -2,6 +2,7 @@
 
 require "audio_monster/version"
 
+require 'active_support/all'
 require 'open3'
 require 'timeout'
 require 'mp3info'
@@ -9,7 +10,7 @@ require 'logger'
 require 'nu_wav'
 require 'tempfile'
 require 'mimemagic'
-require 'active_support/all'
+require 'digest/sha2'
 
 module AudioMonster
 
@@ -741,9 +742,14 @@ module AudioMonster
     alias validate_mp2 validate_mpeg
     alias validate_mp3 validate_mpeg
 
+    MAX_FILENAME_LENGTH = 160
+    MAX_EXTENSION_LENGTH = 6
+
     def create_temp_file(base_file_name=nil, bin_mode=true)
       file_name = File.basename(base_file_name)
-      file_ext = File.extname(base_file_name)
+      file_name = Digest::SHA256.hexdigest(base_file_name) if file_name.length > MAX_FILENAME_LENGTH
+      file_ext = File.extname(base_file_name)[0, MAX_EXTENSION_LENGTH]
+
       FileUtils.mkdir_p(tmp_dir) unless File.exists?(tmp_dir)
       tmp = Tempfile.new([file_name, file_ext], tmp_dir)
       tmp.binmode if bin_mode

--- a/test/monster_test.rb
+++ b/test/monster_test.rb
@@ -108,4 +108,10 @@ describe AudioMonster::Monster do
     slice_wav.duration.must_equal 5
   end
 
+  it 'can create a temp file with a really long name' do
+    base_file_name = ('abc' * 100) + '.extension'
+    file = AudioMonster.create_temp_file(base_file_name)
+    File.basename(file.path)[0, 64].must_equal Digest::SHA256.hexdigest(base_file_name)
+    File.extname(file.path).must_equal '.exten'
+  end
 end


### PR DESCRIPTION
same purpose as #1 

This fixes "File name too long" errors from Tempfile
see e.g. https://github.com/thoughtbot/paperclip/issues/1246
